### PR TITLE
GitHub notification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "puma"
+gem "octokit"
 
 group :test do
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,9 +13,14 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     hashdiff (0.3.0)
     json (1.8.3)
     method_source (0.8.2)
+    multipart-post (2.0.0)
+    octokit (4.3.0)
+      sawyer (~> 0.7.0, >= 0.5.3)
     parser (2.3.1.0)
       ast (~> 2.2)
     powerpack (0.0.9)
@@ -52,6 +57,9 @@ GEM
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.8.0)
     safe_yaml (1.0.4)
+    sawyer (0.7.0)
+      addressable (>= 2.3.5, < 2.5)
+      faraday (~> 0.8, < 0.10)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -69,6 +77,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler-audit
+  octokit
   pry
   puma
   rack-test

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Build Status](https://travis-ci.org/assemblyline/shipping_agent.svg?branch=master)](https://travis-ci.org/assemblyline/shipping_agent)
 
 Shipping Agent listens for Github Deployment Events on a Webhook, and updates Kubernetes to deploy new code.
+While the update of the deployment is in progress Shipping Agent adds Github Deployment statuses to
+update the user.
 
 ### Configuration
 
@@ -13,3 +15,4 @@ Config is set up with environment variables.
 |------------------------|------------|
 |`GITHUB_WEBHOOK_SECRET` | The webhook secret [see](https://developer.github.com/v3/repos/hooks/#create-a-hook) |
 |`LOG_LEVEL`             | The log level to use FATAL, ERROR, WARN, INFO or DEBUG. Defaults to WARN             |
+|`GITHUB_TOKEN`          | The Github OAuth token used for notifications                                        |

--- a/lib/shipping_agent/deploy.rb
+++ b/lib/shipping_agent/deploy.rb
@@ -4,14 +4,12 @@ module ShippingAgent
   class Deploy
     def initialize(info)
       @app       = info[:app].tr("_", "-")
-      @build     = info[:build]
-      @deploy    = info[:deploy]
       @image     = info[:image]
+      @labels  = info[:labels]
       @namespace = info[:namespace]
-      @version   = info[:version]
     end
 
-    attr_reader :app, :build, :deploy, :image, :namespace, :version
+    attr_reader :app, :image, :labels, :namespace
 
     def self.deploy(info)
       new(info).apply
@@ -23,10 +21,10 @@ module ShippingAgent
           name: deployment,
           namespace: namespace,
           body: {
-            "metadata" => metadata,
+            "metadata" => { "labels" => labels },
             "spec" => {
               "template" => {
-                "metadata" => metadata,
+                "metadata" => { "labels" => labels },
                 "spec" => {
                   "containers" => [
                     {
@@ -43,16 +41,6 @@ module ShippingAgent
     end
 
     private
-
-    def metadata
-      {
-        "labels" => {
-          "version" => version,
-          "build"   => build,
-          "deploy"  => deploy,
-        },
-      }
-    end
 
     def deployments
       K8s.deployments(namespace: namespace, selector: { app: app }).map { |deployment| deployment["metadata"]["name"] }

--- a/lib/shipping_agent/github/webhook.rb
+++ b/lib/shipping_agent/github/webhook.rb
@@ -55,10 +55,11 @@ module ShippingAgent
         deployment = JSON.parse(body)["deployment"]
         image = deployment["payload"]["image"]
         {
-          namespace: deployment["environment"],
-          image:     image,
-          app:       image.split("/").last.split(":").first,
-          labels:    labels(deployment),
+          namespace:      deployment["environment"],
+          image:          image,
+          app:            image.split("/").last.split(":").first,
+          labels:         labels(deployment),
+          deployment_url: deployment["url"],
         }
 
       rescue # rubocop:disable Lint/HandleExceptions

--- a/lib/shipping_agent/github/webhook.rb
+++ b/lib/shipping_agent/github/webhook.rb
@@ -53,27 +53,27 @@ module ShippingAgent
 
       def deployment_params(body)
         deployment = JSON.parse(body)["deployment"]
-        image      = deployment["payload"]["image"]
-
+        image = deployment["payload"]["image"]
         {
-          deploy: "github.#{deployment["id"]}",
           namespace: deployment["environment"],
           image:     image,
-        }.merge(image_metadata(image))
+          app:       image.split("/").last.split(":").first,
+          labels:    labels(deployment),
+        }
 
       rescue # rubocop:disable Lint/HandleExceptions
       end
 
       def invalid?(params)
-        [:deploy, :namespace, :image].any? { |p| params[p].nil? }
+        [:namespace, :image, :labels].any? { |p| params[p].nil? }
       end
 
-      def image_metadata(image)
-        tag = image.split(":").last.split("_")
+      def labels(deployment)
+        tag = deployment["payload"]["image"].split(":").last.split("_")
         {
-          app:      image.split("/").last.split(":").first,
-          build:    tag.last,
           version:  tag.first,
+          build:    tag.last,
+          deploy: "github.#{deployment["id"]}",
         }
       end
     end

--- a/lib/shipping_agent/k8s.rb
+++ b/lib/shipping_agent/k8s.rb
@@ -7,6 +7,10 @@ module ShippingAgent
   module K8s
     extend self
 
+    def deployment(namespace:, name:)
+      get(endpoint_for("/apis/extensions/v1beta1/namespaces/#{namespace}/deployments/#{name}"))
+    end
+
     def deployments(namespace:, selector: {})
       endpoint = endpoint_for("/apis/extensions/v1beta1/namespaces/#{namespace}/deployments")
       if selector.any?

--- a/lib/shipping_agent/notification.rb
+++ b/lib/shipping_agent/notification.rb
@@ -1,0 +1,26 @@
+require "octokit"
+require "shipping_agent/logger"
+
+module ShippingAgent
+  module Notification
+    extend self
+    def notify(status, description, url)
+      github.create_deployment_status(
+        url,
+        status,
+        accept: "application/vnd.github.ant-man-preview+json",
+        description: description,
+      )
+    rescue => e
+      LOGGER.warn do
+        "Failed to notify github of #{status}: #{description} - due to : #{e.class} #{e.message}"
+      end
+    end
+
+    private
+
+    def github
+      @github_client ||= Octokit::Client.new(access_token: ENV.fetch("GITHUB_TOKEN"))
+    end
+  end
+end

--- a/spec/unit/deploy_spec.rb
+++ b/spec/unit/deploy_spec.rb
@@ -3,30 +3,32 @@ require "shipping_agent/deploy"
 
 RSpec.describe ShippingAgent::Deploy do
   subject { described_class.new(info) }
+  let(:info) do
+    {
+      app:       "shipping_agent",
+      image:     "quay.io/assemblyline/shipping_agent:f255129c9944d5a597e15e5c11118bd03cb220ad_1234",
+      namespace: "assemblyline",
+      labels: {
+        version:   "f255129c9944d5a597e15e5c11118bd03cb220ad",
+        build:     "1234",
+        deploy:    "github:1233456",
+      },
+      deployment_url: "https://github/deployment/1",
+    }
+  end
+
+  before do
+    allow(ShippingAgent::K8s).to receive(:deployments)
+      .with(namespace: "assemblyline", selector: { app: "shipping-agent" })
+      .and_return([
+        { "metadata" => { "name" => "shipping-agent-api" } },
+        { "metadata" => { "name" => "shipping-agent-worker" } },
+      ])
+    allow(ShippingAgent::Notification).to receive(:notify)
+    allow(ShippingAgent::K8s).to receive(:patch_deployment)
+  end
 
   describe "#apply" do
-    let(:info) do
-      {
-        app:       "shipping_agent",
-        image:     "quay.io/assemblyline/shipping_agent:f255129c9944d5a597e15e5c11118bd03cb220ad_1234",
-        namespace: "assemblyline",
-        labels: {
-          version:   "f255129c9944d5a597e15e5c11118bd03cb220ad",
-          build:     "1234",
-          deploy:    "github:1233456",
-        },
-      }
-    end
-
-    before do
-      allow(ShippingAgent::K8s).to receive(:deployments)
-        .with(namespace: "assemblyline", selector: { app: "shipping-agent" })
-        .and_return([
-          { "metadata" => { "name" => "shipping-agent-api" } },
-          { "metadata" => { "name" => "shipping-agent-worker" } },
-        ])
-    end
-
     it "patches the correct deployments" do
       expect(ShippingAgent::K8s).to receive(:patch_deployment) do |args|
         expect(args[:namespace]).to eq "assemblyline"
@@ -37,6 +39,22 @@ RSpec.describe ShippingAgent::Deploy do
         expect(args[:namespace]).to eq "assemblyline"
         expect(args[:name]).to eq "shipping-agent-worker"
       end.once
+      subject.apply
+    end
+
+    it "sets up a notification" do
+      expect(ShippingAgent::Notification).to receive(:notify)
+        .with(
+          "pending",
+          "Config for shipping-agent-api pushed to kubernetes",
+          "https://github/deployment/1",
+        )
+      expect(ShippingAgent::Notification).to receive(:notify)
+        .with(
+          "pending",
+          "Config for shipping-agent-worker pushed to kubernetes",
+          "https://github/deployment/1",
+        )
       subject.apply
     end
 
@@ -61,6 +79,32 @@ RSpec.describe ShippingAgent::Deploy do
       end.twice
 
       subject.apply
+    end
+  end
+
+  describe "#wait" do
+    it "waits for the deployment to be complete" do
+      expect(ShippingAgent::K8s).to receive(:deployment)
+        .with(namespace: "assemblyline", name: "shipping-agent-api")
+        .and_return(ds(0, 2), ds(1, 3), ds(2, 2))
+        .at_least(3).times
+
+      expect(ShippingAgent::K8s).to receive(:deployment)
+        .with(namespace: "assemblyline", name: "shipping-agent-worker")
+        .and_return(ds(0, 2), ds(1, 3), ds(2, 2))
+        .at_least(3).times
+
+      subject.wait
+    end
+
+    def ds(updated, available)
+      {
+        "status" => {
+          "replicas" => 2,
+          "updatedReplicas" => updated,
+          "availableReplicas" => available,
+        },
+      }
     end
   end
 end

--- a/spec/unit/deploy_spec.rb
+++ b/spec/unit/deploy_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe ShippingAgent::Deploy do
     let(:info) do
       {
         app:       "shipping_agent",
-        build:     "1234",
-        deploy:    "github:1233456",
         image:     "quay.io/assemblyline/shipping_agent:f255129c9944d5a597e15e5c11118bd03cb220ad_1234",
         namespace: "assemblyline",
-        version:   "f255129c9944d5a597e15e5c11118bd03cb220ad",
+        labels: {
+          version:   "f255129c9944d5a597e15e5c11118bd03cb220ad",
+          build:     "1234",
+          deploy:    "github:1233456",
+        },
       }
     end
 
@@ -30,6 +32,7 @@ RSpec.describe ShippingAgent::Deploy do
         expect(args[:namespace]).to eq "assemblyline"
         expect(args[:name]).to eq "shipping-agent-api"
       end.once
+
       expect(ShippingAgent::K8s).to receive(:patch_deployment) do |args|
         expect(args[:namespace]).to eq "assemblyline"
         expect(args[:name]).to eq "shipping-agent-worker"
@@ -40,22 +43,10 @@ RSpec.describe ShippingAgent::Deploy do
     it "patches the image and metadata" do
       expect(ShippingAgent::K8s).to receive(:patch_deployment) do |args|
         expect(args[:body]).to eq(
-          "metadata" => {
-            "labels" => {
-              "version" => info[:version],
-              "build"   => info[:build],
-              "deploy"  => info[:deploy],
-            },
-          },
+          "metadata" => { "labels" => info[:labels] },
           "spec" => {
             "template" => {
-              "metadata" => {
-                "labels" => {
-                  "version" => info[:version],
-                  "build"   => info[:build],
-                  "deploy"  => info[:deploy],
-                },
-              },
+              "metadata" => { "labels" => info[:labels] },
               "spec" => {
                 "containers" => [
                   {

--- a/spec/unit/github_webhook_spec.rb
+++ b/spec/unit/github_webhook_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe ShippingAgent::Github::Webhook do
               build:  build,
               version:    sha,
             },
+            deployment_url: url,
           )
           post "/", body
           expect(last_response).to be_accepted

--- a/spec/unit/github_webhook_spec.rb
+++ b/spec/unit/github_webhook_spec.rb
@@ -102,12 +102,14 @@ RSpec.describe ShippingAgent::Github::Webhook do
 
         it "notifies the deployer" do
           expect(ShippingAgent::Deploy).to receive(:deploy).with(
-            deploy: "github.#{id}",
-            build:  build,
-            version:    sha,
             namespace: namespace,
             image: "quay.io/reevoo/#{app_name}:#{sha}_#{build}",
             app: app_name,
+            labels: {
+              deploy: "github.#{id}",
+              build:  build,
+              version:    sha,
+            },
           )
           post "/", body
           expect(last_response).to be_accepted

--- a/spec/unit/notification_spec.rb
+++ b/spec/unit/notification_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "shipping_agent/notification"
+
+RSpec.describe ShippingAgent::Notification do
+  describe ".notify" do
+    let(:github) { double }
+
+    before do
+      ENV["GITHUB_TOKEN"] = "tokenFoo"
+      allow(Octokit::Client).to receive(:new).with(access_token: "tokenFoo").and_return(github)
+    end
+
+    after do
+      ENV["GITHUB_TOKEN"] = nil
+      described_class.instance_variable_set(:"@github_client", nil)
+    end
+
+    it "notifies github" do
+      expect(github).to receive(:create_deployment_status).with(
+        "https://api.github.com/repos/octocat/example/deployments/1",
+        "pending",
+        accept: "application/vnd.github.ant-man-preview+json",
+        description: "this is a notification test",
+      )
+
+      described_class.notify(
+        "pending",
+        "this is a notification test",
+        "https://api.github.com/repos/octocat/example/deployments/1",
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR adds basic notification to shipping agent, so we can see when shipping agent starts and finishes
deploying something.  This is about the simplest thing that could work, and should be fine for now.

If the process gets killed while the deploy is updating the the success notification happens, so for future work I would like to make it so we can spin off a job to ensure that the final status is updated for sure. In practice I am sure that it will hardly ever happen, but its a bit anoying as it means when shipping_agent self updates it can't notify when its done...