### PR TITLE
Change Notification to Logging

### DIFF
--- a/lib/shipping_agent/deploy.rb
+++ b/lib/shipping_agent/deploy.rb
@@ -65,7 +65,7 @@ module ShippingAgent
             },
           },
         )
-        Notification.update("pending", "Config for #{deployment} pushed to kubernetes", self)
+        LOGGER.info { "Config for #{deployment} pushed to kubernetes" }
       end
     end
 

--- a/spec/feature/deployment_spec.rb
+++ b/spec/feature/deployment_spec.rb
@@ -93,10 +93,6 @@ RSpec.describe "Deploying To Kubernetes" do
     expect(ShippingAgent::Notification).to receive(:update)
       .with("request", "Deployment of `dogfood` to `production` was requested",  an_instance_of(ShippingAgent::Deploy))
     expect(ShippingAgent::Notification).to receive(:update)
-      .with("pending", "Config for dogfood-can pushed to kubernetes",  an_instance_of(ShippingAgent::Deploy))
-    expect(ShippingAgent::Notification).to receive(:update)
-      .with("pending", "Config for dogfood-bowl pushed to kubernetes", an_instance_of(ShippingAgent::Deploy))
-    expect(ShippingAgent::Notification).to receive(:update)
       .with("success", "dogfood deployed sucessfully to production",   an_instance_of(ShippingAgent::Deploy))
 
     post "/", body

--- a/spec/unit/deploy_spec.rb
+++ b/spec/unit/deploy_spec.rb
@@ -43,22 +43,6 @@ RSpec.describe ShippingAgent::Deploy do
       subject.apply
     end
 
-    it "sets up a notification" do
-      expect(ShippingAgent::Notification).to receive(:update)
-        .with(
-          "pending",
-          "Config for shipping-agent-api pushed to kubernetes",
-          subject,
-        )
-      expect(ShippingAgent::Notification).to receive(:update)
-        .with(
-          "pending",
-          "Config for shipping-agent-worker pushed to kubernetes",
-          subject,
-        )
-      subject.apply
-    end
-
     it "patches the image and metadata" do
       expect(ShippingAgent::K8s).to receive(:patch_deployment) do |args|
         expect(args[:body]).to eq(


### PR DESCRIPTION
We get notifications about these pushes every time we deploy, which is
only interesting for debugging, we don't need 4 messages per deploy into
slack